### PR TITLE
osi/1147

### DIFF
--- a/src/main/java/com/jss/osiris/modules/quotation/service/AnnouncementStatusServiceImpl.java
+++ b/src/main/java/com/jss/osiris/modules/quotation/service/AnnouncementStatusServiceImpl.java
@@ -84,6 +84,11 @@ public class AnnouncementStatusServiceImpl implements AnnouncementStatusService 
 
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW, AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW, AnnouncementStatus.ANNOUNCEMENT_WAITING_DOCUMENT);
+                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW,
+                                AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER);
+                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW,
+                                AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE);
+
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,
                                 AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER);
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,


### PR DESCRIPTION
1. Ajouter un statut ‘En attente de l’épreuve de relecture'.

On peut accéder à ce statut directement après ‘Ouvert’ - il est au meme niveau que le statut ‘en cours’ du coup.

On peut uniquement accéder au statut ‘en cours’ depuis le statut ‘en attente de l’épreuve de relecture' ou reculer à 'ouvert'.

 

Le but est de permettre d’envoyer le mail de la demande d'épreuve de relecture avant de passer par le mail d’envoi de l’attestation qui est envoyé au passage ‘en cours’.

2. Modifier le statut 'en attente du confrere'

Modifier ce statut pour qu’il soit accessbile directement depuis le statut ‘nouveau’.

Et ensuite il faut pouvoir aller de ‘en attente du confrere’ à ‘en cours’ (mais ca je crois que c’est deja OK.

Le but est de ne pas passer par ‘en cours' (vu que c’est la qu’on demande d’envoyer l’attestation de parution alors qu’on ne l’a pas encor puisquelle nous est donnée par le confrere après qu’on lui ait envoyé le mail de demande de pub (passage au statut ‘en attente du confrere’)