### PR TITLE
Feature/osi 1147

### DIFF
--- a/src/main/java/com/jss/osiris/modules/quotation/service/AnnouncementStatusServiceImpl.java
+++ b/src/main/java/com/jss/osiris/modules/quotation/service/AnnouncementStatusServiceImpl.java
@@ -84,6 +84,11 @@ public class AnnouncementStatusServiceImpl implements AnnouncementStatusService 
 
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW, AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW, AnnouncementStatus.ANNOUNCEMENT_WAITING_DOCUMENT);
+                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW,
+                                AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER);
+                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW,
+                                AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE);
+
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,
                                 AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER);
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,

--- a/src/main/java/com/jss/osiris/modules/quotation/service/AnnouncementStatusServiceImpl.java
+++ b/src/main/java/com/jss/osiris/modules/quotation/service/AnnouncementStatusServiceImpl.java
@@ -82,28 +82,33 @@ public class AnnouncementStatusServiceImpl implements AnnouncementStatusService 
                 updateStatus(AnnouncementStatus.ANNOUNCEMENT_DONE, "Terminé", "check_small", false, true,
                                 AggregateStatus.AGGREGATE_STATUS_DONE);
 
-                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW, AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
-                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW, AnnouncementStatus.ANNOUNCEMENT_WAITING_DOCUMENT);
+                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW,
+                                AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
+                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW,
+                                AnnouncementStatus.ANNOUNCEMENT_WAITING_DOCUMENT);
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW,
                                 AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER);
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_NEW,
                                 AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE);
 
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,
-                                AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER);
+                                AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE_PUBLISHED);
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,
-                                AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE_PUBLISHED);
-                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS, AnnouncementStatus.ANNOUNCEMENT_PUBLISHED);
-                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER,
-                                AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE_PUBLISHED);
-                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER,
                                 AnnouncementStatus.ANNOUNCEMENT_PUBLISHED);
-                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_PUBLISHED, AnnouncementStatus.ANNOUNCEMENT_DONE);
+
+                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_PUBLISHED,
+                                AnnouncementStatus.ANNOUNCEMENT_DONE);
 
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE_PUBLISHED,
                                 AnnouncementStatus.ANNOUNCEMENT_PUBLISHED);
+
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,
                                 AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE);
+                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,
+                                AnnouncementStatus.ANNOUNCEMENT_WAITING_DOCUMENT);
+
+                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER,
+                                AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE,
                                 AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
 
@@ -112,30 +117,33 @@ public class AnnouncementStatusServiceImpl implements AnnouncementStatusService 
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE,
                                 AnnouncementStatus.ANNOUNCEMENT_PUBLISHED);
 
-                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE,
-                                AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER);
-                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,
-                                AnnouncementStatus.ANNOUNCEMENT_WAITING_DOCUMENT);
                 setSuccessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_DOCUMENT,
                                 AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
-                setSuccessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_DOCUMENT,
-                                AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER);
 
                 setPredecessor(AnnouncementStatus.ANNOUNCEMENT_DONE,
                                 AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE_PUBLISHED);
+                setPredecessor(AnnouncementStatus.ANNOUNCEMENT_DONE,
+                                AnnouncementStatus.ANNOUNCEMENT_PUBLISHED);
+
                 setPredecessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE_PUBLISHED,
                                 AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
-                setPredecessor(AnnouncementStatus.ANNOUNCEMENT_DONE, AnnouncementStatus.ANNOUNCEMENT_PUBLISHED);
-                setPredecessor(AnnouncementStatus.ANNOUNCEMENT_PUBLISHED, AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
+
                 setPredecessor(AnnouncementStatus.ANNOUNCEMENT_PUBLISHED,
-                                AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER);
-                setPredecessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER,
                                 AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
-                setPredecessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS, AnnouncementStatus.ANNOUNCEMENT_NEW);
+
+                setPredecessor(AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS,
+                                AnnouncementStatus.ANNOUNCEMENT_NEW);
+
+                setPredecessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE,
+                                AnnouncementStatus.ANNOUNCEMENT_NEW);
                 setPredecessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_CONFRERE,
                                 AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
+
                 setPredecessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_DOCUMENT,
                                 AnnouncementStatus.ANNOUNCEMENT_IN_PROGRESS);
+
+                setPredecessor(AnnouncementStatus.ANNOUNCEMENT_WAITING_READ_CUSTOMER,
+                                AnnouncementStatus.ANNOUNCEMENT_NEW);
 
         }
 
@@ -151,6 +159,7 @@ public class AnnouncementStatusServiceImpl implements AnnouncementStatusService 
         protected void updateStatus(String code, String label, String icon, boolean isOpenState, boolean isCloseState,
                         String aggregateStatus) {
                 AnnouncementStatus announcementStatus = getAnnouncementStatusByCode(code);
+
                 if (getAnnouncementStatusByCode(code) == null)
                         announcementStatus = new AnnouncementStatus();
                 announcementStatus.setPredecessors(null);

--- a/src/main/java/com/jss/osiris/modules/quotation/service/AssoAffaireOrderServiceImpl.java
+++ b/src/main/java/com/jss/osiris/modules/quotation/service/AssoAffaireOrderServiceImpl.java
@@ -297,6 +297,13 @@ public class AssoAffaireOrderServiceImpl implements AssoAffaireOrderService {
                 // Handle status change
                 if (announcement.getAnnouncementStatus() != null && announcement.getConfrere() != null) {
 
+                    if (announcement.getConfrere().getId().equals(constantService.getConfrereJssSpel().getId()) &&
+                            announcement.getAnnouncementStatus().getCode()
+                                    .equals(AnnouncementStatus.ANNOUNCEMENT_PUBLISHED)) {
+                        announcement.setAnnouncementStatus(announcementStatusService
+                                .getAnnouncementStatusByCode(AnnouncementStatus.ANNOUNCEMENT_DONE));
+                    }
+
                     // If JSS generate publication receipt if user accept
                     if (announcement.getConfrere().getId().equals(constantService.getConfrereJssSpel().getId())) {
                         if (announcement.getAnnouncementStatus().getCode()


### PR DESCRIPTION
avant l'évolution, En attente de l’épreuve de relecture était dispo depuis le statut En cours et En attente de document. Maintenant, on le veut QUE depuis le statut Nouveau. Et depuis le statut En attente de l’épreuve de relecture, on ne doit pouvoir revenir QUE à Nouveau ou bien avancer à En cours.