### PR TITLE
ajout de contage des characteres announce semaine

### DIFF
--- a/client/src/app/libs/Dictionnary.ts
+++ b/client/src/app/libs/Dictionnary.ts
@@ -1,6 +1,6 @@
 
 export const Dictionnary = {
-  "weeklyCharReport": "semaine de publication",
+
   "notice": "Texte de l'annonce",
   "affaireId": "N° de l'affaire",
   "affaireSiren": "SIREN de l'affaire",
@@ -24,6 +24,6 @@ export const Dictionnary = {
   "customerOrderCreatedDateMonth": "Mois de la commande",
   "invoiceDateMonth": "Mois de la facture",
   "characterNumber": "Nombre de caractères",
-
+  "publicationDateWeek": "Semaine de publication",
 };
 

--- a/client/src/app/libs/Dictionnary.ts
+++ b/client/src/app/libs/Dictionnary.ts
@@ -1,5 +1,6 @@
 
 export const Dictionnary = {
+  "weeklyCharReport": "semaine de publication",
   "notice": "Texte de l'annonce",
   "affaireId": "N° de l'affaire",
   "affaireSiren": "SIREN de l'affaire",
@@ -23,5 +24,6 @@ export const Dictionnary = {
   "customerOrderCreatedDateMonth": "Mois de la commande",
   "invoiceDateMonth": "Mois de la facture",
   "characterNumber": "Nombre de caractères",
+
 };
 

--- a/client/src/app/modules/reporting/model/QuotationReporting.ts
+++ b/client/src/app/modules/reporting/model/QuotationReporting.ts
@@ -21,4 +21,5 @@ export interface QuotationReporting {
   customerOrderCreatedDateMonth: string;
   characterNumber: number;
   invoiceDateMonth: string;
+  weeklyCharReport: string;
 }

--- a/client/src/app/modules/reporting/model/QuotationReporting.ts
+++ b/client/src/app/modules/reporting/model/QuotationReporting.ts
@@ -21,5 +21,5 @@ export interface QuotationReporting {
   customerOrderCreatedDateMonth: string;
   characterNumber: number;
   invoiceDateMonth: string;
-  weeklyCharReport: string;
+  publicationDateWeek: string;
 }

--- a/src/main/java/com/jss/osiris/modules/reporting/model/IQuotationReporting.java
+++ b/src/main/java/com/jss/osiris/modules/reporting/model/IQuotationReporting.java
@@ -45,5 +45,5 @@ public interface IQuotationReporting {
 
     public Integer getCharacterNumber();
 
-    public String getWeeklyCharReport();
+    public String getPublicationDateWeek();
 }

--- a/src/main/java/com/jss/osiris/modules/reporting/model/IQuotationReporting.java
+++ b/src/main/java/com/jss/osiris/modules/reporting/model/IQuotationReporting.java
@@ -44,4 +44,6 @@ public interface IQuotationReporting {
     public String getInvoiceDateMonth();
 
     public Integer getCharacterNumber();
+
+    public String getWeeklyCharReport();
 }

--- a/src/main/java/com/jss/osiris/modules/reporting/repository/QuotationReportingRepository.java
+++ b/src/main/java/com/jss/osiris/modules/reporting/repository/QuotationReportingRepository.java
@@ -26,7 +26,7 @@ public interface QuotationReportingRepository extends CrudRepository<Quotation, 
                         " customer_order_status.label as customerOrderStatusLabel, " +
                         " provision_ft.label as provisionFamilyTypeLabel, " +
                         " coalesce(initcap(to_char(a.publication_date,'tmmonth')),'N/A') as publicationDateMonth, " +
-                        " coalesce(initcap(to_char(a.publication_date,'tmw')),'N/A') as weeklyCharReport, " +
+                        " coalesce(initcap(to_char(a.publication_date,'tmw')),'N/A') as publicationDateWeek, " +
                         " coalesce(initcap(to_char(invoice.created_date,'tmmonth')),'N/A') as invoiceDateMonth, " +
                         " coalesce(initcap(to_char(customer_order.created_date,'tmmonth')),'N/A') as customerOrderCreatedDateMonth, "
                         +

--- a/src/main/java/com/jss/osiris/modules/reporting/repository/QuotationReportingRepository.java
+++ b/src/main/java/com/jss/osiris/modules/reporting/repository/QuotationReportingRepository.java
@@ -26,6 +26,7 @@ public interface QuotationReportingRepository extends CrudRepository<Quotation, 
                         " customer_order_status.label as customerOrderStatusLabel, " +
                         " provision_ft.label as provisionFamilyTypeLabel, " +
                         " coalesce(initcap(to_char(a.publication_date,'tmmonth')),'N/A') as publicationDateMonth, " +
+                        " coalesce(initcap(to_char(a.publication_date,'tmw')),'N/A') as weeklyCharReport, " +
                         " coalesce(initcap(to_char(invoice.created_date,'tmmonth')),'N/A') as invoiceDateMonth, " +
                         " coalesce(initcap(to_char(customer_order.created_date,'tmmonth')),'N/A') as customerOrderCreatedDateMonth, "
                         +


### PR DESCRIPTION
·         La Rédaction se demande comment savoir combien de signes sont publiés (dans le cadre de l’obligation 50/50 avec les annonces légales), afin de savoir combien il lui reste à écrire chaque semaine pour être dans les clous. Peut-être faudrait-il ajouter un outil sur Osiris dans ce sens, bien que la partie dédiée à la Rédaction ne soit pas encore construite. La Rédaction se demande d’ailleurs à quoi va lui servir Osiris, surtout avec le site actuel, puisqu’elle fonctionne sans cette plateforme depuis 3 mois et que le système de dossiers sur le réseau convient très bien.